### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub",
+        "schedule": "Wednesdays, 3:00 PM - 4:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the activities list, as requested in issue #6. The activity allows students to sign up for practical coding and collaboration skills training.

Changes:
- Added "GitHub Skills" entry to the activities dictionary in src/app.py with description, schedule, max participants, and empty participants list.

Closes #6